### PR TITLE
fix end rounding of rails

### DIFF
--- a/assembly.scad
+++ b/assembly.scad
@@ -1,4 +1,4 @@
 include<needleBed.scad>;
 include<backCover.scad>;
 include<spongeBar.scad>;
-//include<carriageRest.scad>;
+include<carriageRest.scad>;

--- a/backCover.scad
+++ b/backCover.scad
@@ -1,5 +1,6 @@
 include<params.scad>;
 use<needlebedScrews.scad>;
+use<roundedRail.scad>;
 
 module backCover(width = gauge) { 
 //    union () {
@@ -13,17 +14,11 @@ module backCover(width = gauge) {
 
 module backRail(width = gauge, rounded = false, tolerance = tolerance) {
     translate([0,-BACK_COVER/2, railHeight/2]) {
-        cube([width, railDepth - tolerance*2, railHeight], center = true);
+//        cube([width, railDepth - tolerance*2, railHeight], center = true);
         if (rounded) {
-            hull () {
-                $fn = 50;
-                translate([-width/2 + tolerance*2,0,-railHeight/2 + 0.5])
-                cylinder(1, d = railDepth-tolerance*2, center = true);
-                translate([-width/2 + tolerance*2,0,0])
-                sphere(d = railDepth-tolerance*2);
-                translate([-width/2 + tolerance*2,0,0])
-                cube([1, railDepth-tolerance*2, railHeight], center = true);
-            }
+            roundedRail(width, railDepth - tolerance*2, railHeight);
+        } else {
+            cube([width, railDepth - tolerance*2, railHeight], center = true);
         }
     }
 }
@@ -45,8 +40,8 @@ difference() {
 //        translate([gauge*numNeedles, 0, 0])
 //        backRail(rounded = true);  
         translate([(gauge*numNeedles)/2 - gauge/2, 0, 0]) {
-        backRail(width = (numNeedles - 1) * gauge, rounded = true);
-            mirror([1,0,0])
-                    backRail(width = (numNeedles - 1) * gauge, rounded = true);
+        backRail(width = numNeedles * gauge, rounded = true);
+//            mirror([1,0,0])
+//                    backRail(width = (numNeedles - 1) * gauge, rounded = false);
         }
-            
+     

--- a/params.scad
+++ b/params.scad
@@ -13,7 +13,7 @@ I recommend only modifying these constants if you are also
 making changes to the cam design in the technical sketch.
 */
 
-gauge = 6.5;
+gauge = 4.5;
 numNeedles = 25;
 tolerance = 0.2; // allows a bit of room for parts that have to fit together; adjust according to your printer's precision
 

--- a/roundedRail.scad
+++ b/roundedRail.scad
@@ -1,0 +1,22 @@
+include<params.scad>;
+
+module roundedRail(width,depth,height) {
+    $fn = 30;
+    rad = depth/2;
+    translate([-width/2,0,0])
+    hull() {
+        translate([width/2,0,0])
+        cube([width-rad*3,depth,height], center = true);
+        translate([rad, 0, height/2 - rad]) {
+            sphere(rad);
+            translate([0,0,-height/2 + 0.5])
+            cylinder(1,rad,rad, center = true);
+        }
+        translate([width - rad,0,0])
+        {
+            sphere(rad);
+            translate([0,0,-height/2 + 0.5])
+            cylinder(1,rad,rad, center = true);
+        }
+    }
+}

--- a/spongeBar.scad
+++ b/spongeBar.scad
@@ -1,58 +1,33 @@
 include<params.scad>;
 use<needlebedScrews.scad>;
+use<roundedRail.scad>;
+
 
 module spongeBar(width = gauge) { 
-//        difference() {
-//        union () {
-//            frontRail();
             translate([0,-(NEEDLE_BED_DEPTH-COMB) + SPONGE_BAR/2, -1])
             cube([width,SPONGE_BAR - tolerance*2,2], center = true);
-//        }
-//    }
 }
 
 module frontRail(width = gauge, rounded = false, tolerance = tolerance) {
     translate([0,-(NEEDLE_BED_DEPTH-COMB) + SPONGE_BAR/2, railHeight/2]) {
-        cube([width, railDepth - tolerance*2, railHeight], center = true);
-//        if (rounded) {
-//            translate([-width/2,0,0])
-//            cylinder(railHeight, d = railDepth-tolerance*2, center = true);
-//        }
         if (rounded) {
-            hull () {
-                $fn = 50;
-                translate([-width/2 + tolerance*2,0,-railHeight/2 + 0.5])
-                cylinder(1, d = railDepth-tolerance*2, center = true);
-                translate([-width/2 + tolerance*2,0,0])
-                sphere(d = railDepth-tolerance*2);
-                translate([-width/2 + tolerance*2,0,0])
-                cube([1, railDepth-tolerance*2, railHeight], center = true);
-            }
+            roundedRail(width, railDepth - tolerance*2, railHeight);
+        } else {
+            cube([width, railDepth - tolerance*2, railHeight], center = true);
         }
     }
 }
 
-//difference() {
-//    union() {
-//        for(i = [0:numNeedles-1]) {
-//            translate([gauge*i, 0, 0])
-//            spongeBar();
-//        }
-//    }
-//    needleBedScrews();
-//}
+
 
 difference() {
     union() {
         translate([(gauge*numNeedles)/2 - gauge/2, 0, 0]) {
-        frontRail(width = (numNeedles - 1) * gauge, rounded = true);
-            mirror([1,0,0])
-                    frontRail(width = (numNeedles - 1) * gauge, rounded = true);
+        frontRail(width = (numNeedles) * gauge, rounded = true);
         }
                     translate([gauge*numNeedles/2 - gauge/2, 0, 0])
 
             spongeBar(width = numNeedles*gauge);
-//        }
     }
         needleBedScrews();
 }


### PR DESCRIPTION
This change will fix the rounded ends of the carriage rails so they are placed and scaled appropriately for both 4.5 (standard-) and 6.5 (mid-) gauges.