### PR TITLE
WIP: makes needleslot left-aligned in needleunit

### DIFF
--- a/SCAD/parts/backCover.scad
+++ b/SCAD/parts/backCover.scad
@@ -22,7 +22,7 @@ difference() {
     translate([gauge*numNeedles/2 - gauge/2, 0, 0])
     
     backCover(width = numNeedles*gauge);
-    needleBedScrews();
+    translate([-needleSlotWidth,0,0]) needleBedScrews();
 }
 
 

--- a/SCAD/parts/needlebed.scad
+++ b/SCAD/parts/needlebed.scad
@@ -19,7 +19,7 @@ module needleBase() {
 }
 
 module needleSlot() {
-    translate([0,-NEEDLE_BED_DEPTH/2, 0])
+    translate([-needleSlotWidth,-NEEDLE_BED_DEPTH/2, 0])
     cube([needleSlotWidth, NEEDLE_BED_DEPTH + 2, needleSlotHeight*2], center = true);
 }
 
@@ -35,13 +35,21 @@ module spongeBarCutout() {
 
 module combCutout() {
     hull() {
-        translate([0,-NEEDLE_BED_DEPTH, 0])    
+        translate([-needleSlotWidth,-NEEDLE_BED_DEPTH, 0])    
         cube([combWidth,(COMB - combWidth)*2,needleSlotHeight * 2], center = true);
-        translate([0,-NEEDLE_BED_DEPTH + (COMB - combWidth), 0])
+        translate([-needleSlotWidth,-NEEDLE_BED_DEPTH + (COMB - combWidth), 0])
         cylinder(h = needleSlotHeight * 2, r = combWidth/2, $fn = 25, center = true);
     }
-    translate([0,-NEEDLE_BED_DEPTH, 0])
+    translate([-needleSlotWidth,-NEEDLE_BED_DEPTH, 0])
         cylinder(h = needleBedHeight * 2 + 1, r = combWidth/2, $fn = 25, center = true);
+    
+    translate([needleSlotWidth,0,0]) hull() {
+        translate([needleSlotWidth,-NEEDLE_BED_DEPTH, 0])    
+        cube([combWidth,(COMB - combWidth)*2,needleSlotHeight * 2], center = true);
+        translate([needleSlotWidth,-NEEDLE_BED_DEPTH + (COMB - combWidth), 0])
+        cylinder(h = needleSlotHeight * 2, r = combWidth/2, $fn = 25, center = true);
+    }
+    translate([needleSlotWidth,0,0]) translate([needleSlotWidth,-NEEDLE_BED_DEPTH, 0]) cylinder(h = needleBedHeight * 2 + 1, r = combWidth/2, $fn = 25, center = true);
 }
 
 module frontAngle(width = gauge) {
@@ -65,7 +73,7 @@ union() {
         #connector();
         translate([-gauge/2 - tolerance,-(NEEDLE_BED_DEPTH-connectorOffset),-needleBedHeight - tolerance])
         #connector();
-        needleBedScrews();
+        translate([-needleSlotWidth,0,0])needleBedScrews();
     }
     translate([gauge*(numNeedles-1)+gauge/2,-connectorOffset,-needleBedHeight])
                 connector(tolerance = tolerance);
@@ -79,7 +87,7 @@ module needleBed() {
         if (i==screwPlacement || i==numNeedles-screwPlacement) {
               translate([gauge*i, 0, 0]) {
               needleUnit(); 
-              spongeBarSpacers();
+              translate([-needleSlotWidth,0,0]) spongeBarSpacers();
               } 
         } else {
             // no spacer

--- a/SCAD/parts/spongeBar.scad
+++ b/SCAD/parts/spongeBar.scad
@@ -29,6 +29,6 @@ difference() {
 
             spongeBar(width = numNeedles*gauge);
     }
-        needleBedScrews();
+        translate([-needleSlotWidth,0,0]) needleBedScrews();
 }
 


### PR DESCRIPTION
Prior to this change, needleunits have centred needleslots. This leads to thin walls on each side of the needlebed, which are prone to breaking off. This is at its worst on 4.5mm gauge.

This commit adjusts the needleslot to be left-aligned. This changes the overall geometry of the needlebed and required additional adjustments to the spongebar and backcover parts. A small change may still be needed on the left mounting bracket. As this part is currently undergoing refactoring, this was deferred. For this reason, the new parts have not yet been test-printed!

The needleslot not being left-aligned has one major downside: The left-most needle on each needlebed has no support when the knitting machine is disassembled. It will fall out, unless secured by tape or other means.

<img width="381" height="412" alt="needlebed" src="https://github.com/user-attachments/assets/b8e5bcf6-b479-4aae-afd5-de22b22f58b2" />
