### PR TITLE
Add needlebed with pole mount for tension mast and params

### DIFF
--- a/SCAD/modules/params.scad
+++ b/SCAD/modules/params.scad
@@ -76,6 +76,12 @@ connectorOffset = 20;
 
 screwPlacement = 3; // how many needles from edge of bed; min 2, max floor(numNeedles/2)
 
+poleDiameter = 4.5; //0.1
+poleHeight = 60; // 
+knotchWidth = 6; //0.1
+knotchDepth = 1.5; //0.1
+wallThickness = 4; //0.5
+
 // ---
 // Carriage dimensions
 // refer to technical sketch

--- a/SCAD/parts/needlebedWithPole.scad
+++ b/SCAD/parts/needlebedWithPole.scad
@@ -1,0 +1,56 @@
+include<../modules/params.scad>;
+use<../modules/needlebedScrews.scad>;
+use<../modules/connector.scad>;
+use<needlebed.scad>;
+
+holeCutout = poleHeight - 2;
+bedCentreX = gauge * (numNeedles - 1) / 2;
+edgeLength = (wallThickness * 2) + poleDiameter;
+base = 0 - needleBedHeight;
+
+module poleMount() {
+    translate([bedCentreX, edgeLength / 2, base +(poleHeight / 2)])
+    cube([edgeLength, edgeLength, poleHeight], center = true);
+    
+    translate([bedCentreX, edgeLength / 2, base / 2 ])
+    cube([poleHeight, edgeLength, needleBedHeight], center = true);
+}
+
+module poleMountHole() {
+    translate([bedCentreX, edgeLength / 2, base + 2])
+    cylinder(h = holeCutout, d = poleDiameter, $fn = 40);
+}
+
+module poleMountSlot() {
+    translate([bedCentreX, edgeLength / 2, (holeCutout / 2) + base + 2])
+    cube([knotchWidth, knotchDepth, holeCutout], center = true);
+}
+
+module poleMountSupport() {
+    translate([bedCentreX - (poleHeight / 2) , edgeLength, 0])
+    rotate([90, 0, 0])
+    linear_extrude(height = edgeLength)
+    polygon(points = [[0, 0],[poleHeight / 2, poleHeight + base],[60, 0]]);
+}
+
+union() {
+    difference() {
+        union() {
+            needleBed();
+            poleMountSupport();
+            poleMount();
+        }
+        #poleMountHole();
+        #poleMountSlot();
+        translate([-gauge/2 - tolerance,-connectorOffset,-needleBedHeight-tolerance])
+        #connector();
+        translate([-gauge/2 - tolerance,-(NEEDLE_BED_DEPTH-connectorOffset),-needleBedHeight - tolerance])
+        #connector();
+        needleBedScrews();
+    }
+    translate([gauge*(numNeedles-1)+gauge/2,-connectorOffset,-needleBedHeight])
+                connector(tolerance = tolerance);
+                translate([gauge*(numNeedles-1)+gauge/2,-(NEEDLE_BED_DEPTH-connectorOffset),-needleBedHeight])
+                connector(tolerance = tolerance);
+}    
+


### PR DESCRIPTION
New parameters (poleDiameter, poleHeight, notchWidth, notchDepth, wallThickness) in params.scad to control pole mount. Add SCAD/parts/needlebedWithPole.scad which implements a pole mount onto the needle bed with the existing needleBed().